### PR TITLE
Removed word "file" from description (see Issue 2623)

### DIFF
--- a/cpp/ql/src/Critical/DescriptorNeverClosed.ql
+++ b/cpp/ql/src/Critical/DescriptorNeverClosed.ql
@@ -1,6 +1,6 @@
 /**
  * @name Open descriptor never closed
- * @description Functions that always return before closing the socket or file they opened leak resources.
+ * @description Functions that always return before closing the socket they opened leak resources.
  * @kind problem
  * @id cpp/descriptor-never-closed
  * @problem.severity warning


### PR DESCRIPTION
This pull request is in reference to Issue #2623 - "DescriptorNeverClosed.ql identifies only sockets (not file handles)"